### PR TITLE
パッケージマネージャー統一する

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "start": "next start",
     "lint": "next lint"
   },
+	"engines": {
+    "yarn": ">= 1.22.0",
+    "npm": "use yarn instead."
+  },
   "dependencies": {
     "@types/node": "20.2.5",
     "@types/react": "18.2.7",


### PR DESCRIPTION
Resolve #17 

画像のような差分が作られると非常に困るため。
pnpmについてはフォローしませんが、それ使う人は多分わかってるはずなので、、、(yarn v1だとinvalidとして扱われるのでやりたくても微妙って感じ)

![image](https://github.com/el4s-ih14-2023/frontend_base/assets/49822810/094cf175-2d77-4ef8-8ca2-26909712eddd)
